### PR TITLE
Create valid NFO files when non-ascii chars present in input

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -21,7 +21,13 @@
 	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17">
 		<attributes>
+			<attribute name="module" value="true"/>
 			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/5">
+		<attributes>
+			<attribute name="org.eclipse.jst.component.nondependency" value=""/>
 		</attributes>
 	</classpathentry>
 	<classpathentry excluding="**" kind="src" output="target/classes" path="src/main/resources">

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@ tvguide/**
 !tvguide/script/*
 !tvguide/crit
 !tvguide/crit/*
+!tvguide/xml
+!tvguide/xml/mergexmltv.xmltv
 **/*.bak
 *.diff
 *.log

--- a/HTMLMaker(transform).launch
+++ b/HTMLMaker(transform).launch
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="org.eclipse.jdt.launching.localJavaApplication">
+    <booleanAttribute key="org.eclipse.debug.core.ATTR_FORCE_SYSTEM_CONSOLE_ENCODING" value="false"/>
+    <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
+        <listEntry value="/xmltransform/src/main/java/com/scu/xmltv/HTMLMaker.java"/>
+    </listAttribute>
+    <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
+        <listEntry value="1"/>
+    </listAttribute>
+    <listAttribute key="org.eclipse.debug.ui.favoriteGroups">
+        <listEntry value="org.eclipse.debug.ui.launchGroup.debug"/>
+    </listAttribute>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_ATTR_USE_ARGFILE" value="false"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_EXCLUDE_TEST_CODE" value="true"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_SHOW_CODEDETAILS_IN_EXCEPTION_MESSAGES" value="true"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_CLASSPATH_ONLY_JAR" value="false"/>
+    <stringAttribute key="org.eclipse.jdt.launching.CLASSPATH_PROVIDER" value="org.eclipse.m2e.launchconfig.classpathProvider"/>
+    <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="com.scu.xmltv.HTMLMaker"/>
+    <stringAttribute key="org.eclipse.jdt.launching.MODULE_NAME" value="xmltransform"/>
+    <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-xml &quot;..\xml\mergexmltv.xmltv&quot; -xsl &quot;..\bin\tvguide.xsl&quot; -xfrm &quot;00favorites.htm&quot; -out &quot;..\tv&quot; -fav &quot;..\crit\favcrit.xml&quot;"/>
+    <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="xmltransform"/>
+    <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.m2e.launchconfig.sourcepathProvider"/>
+    <stringAttribute key="org.eclipse.jdt.launching.WORKING_DIRECTORY" value="${workspace_loc:xmltransform/tvguide/bin}"/>
+</launchConfiguration>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.felixalacampagne</groupId>
   <artifactId>xmltransform</artifactId>
-  <version>0.17.2-SNAPSHOT</version>
+  <version>0.17.3-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>xmltransform</name>
   <description>Perform enhanced XSLT transforms</description>

--- a/src/main/java/com/scu/xmltv/XSLTExtensions.java
+++ b/src/main/java/com/scu/xmltv/XSLTExtensions.java
@@ -1,4 +1,5 @@
 package com.scu.xmltv;
+
 import java.io.StringReader;
 import java.io.StringWriter;
 import java.net.URLEncoder;
@@ -286,7 +287,7 @@ static ObjectMapper mapper = new ObjectMapper();
          // This is the Unix way of representing a datetime. Will use this to try and avoid timezone
          // issues when setting programmes from a device using a different timezone to the set-top box, eg.
          // when using iPhone in UK and STB in Be.
-         rs = "" + dt.getTime(); 
+         rs = "" + dt.getTime();
       }
       catch(Exception ex) {}
 
@@ -296,7 +297,7 @@ static ObjectMapper mapper = new ObjectMapper();
    // This is to allow the timerlist page to issue a warning that the device
    // timezone is not the same as the one used for the EPG times. Only required
    // because I couldn't find a way in 'standard' jaavascript to force the unix Date
-   // values to be displayed using a summertime aware timezone. 
+   // values to be displayed using a summertime aware timezone.
    // This is only an issue when using iPhone which adjusts the local timezone
    // according to the location and javascript converts Dates using the local
    // device timezone.
@@ -304,18 +305,18 @@ static ObjectMapper mapper = new ObjectMapper();
    // WARNING: This doesn't really do what is required as it gives the timezone offset
    // in effect when the EPG pages are generated but the device will be calculating
    // the offset when the link is clicked and the page is viewed so the two calculations
-   // could be made either side of a daylight saving transition! It should only give 
-   // false positives though so is good enough provided the value is not used 
+   // could be made either side of a daylight saving transition! It should only give
+   // false positives though so is good enough provided the value is not used
    // for any program time calculations.
-   public static String getTimeZoneOffset() 
+   public static String getTimeZoneOffset()
    {
    	// NB. All the relevant methods of Date have been deprecated so should use Calendar!
    	Calendar nowlocal = Calendar.getInstance();
    	int off = nowlocal.getTimeZone().getOffset(nowlocal.getTimeInMillis()) / 1000 / 60;
    	return String.valueOf(off);
    }
-   
-   
+
+
    public static boolean isDateInRange(String mindate, String maxdate, String xmltvdatetime)
    {
    boolean rb = false;
@@ -383,7 +384,8 @@ static ObjectMapper mapper = new ObjectMapper();
          Transformer tfmr = TransformerFactory.newInstance().newTransformer();
          tfmr.setOutputProperty(OutputKeys.MEDIA_TYPE, "text/xml");
          tfmr.setOutputProperty(OutputKeys.INDENT, "yes"); // This doesn't give indenting
-
+         tfmr.setOutputProperty(OutputKeys.ENCODING, "utf8");
+         
          // This gives unrecognised property exception, with or without xalan: prefix.
          // Google revealed the weird URL format to me which doesn't give an error.
          // The indentation only appears if the output type is set to XML.
@@ -405,7 +407,7 @@ static ObjectMapper mapper = new ObjectMapper();
    String xml =  null;
 
       xml = nodeToXml(value);
-      FileTools.writeStringToFile(file, xml);
+      FileTools.writeStringToFile(file, xml, "utf-8");
       return "";
    }
 

--- a/tvguide/xml/mergexmltv.xmltv
+++ b/tvguide/xml/mergexmltv.xmltv
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<tv>
+  <channel id="683.tvguide.co.uk">
+    <display-name lang="en">BBC One HD</display-name>
+  </channel>
+
+  <programme channel="683.tvguide.co.uk" start="20230714210000 +0100" stop="20230714213000 +0100">
+    <title lang="en">Not Going Out</title>
+    <sub-title lang="en">Coffin</sub-title>
+    <desc lang="en">Lee wakes up inside a coffin and is unable remember how he got there, until a phone call from Lucy reminds him what he had been doing that afternoon. Now all he needs to do is keep her in the dark as to his exact location and work out how to escape. Comedy, starring Lee Mack.</desc>
+    <credits>
+      <actor>Lee Mack</actor>
+    </credits>
+    <category lang="en">Sitcom</category>
+    <url>https://www.tvguide.co.uk/detail/5164863/83998077/not-going-out</url>
+    <episode-num system="xmltv_ns">12 . 3/7 . </episode-num>
+    <subtitles type="teletext"/>
+    <star-rating>
+      <value>7.9/10</value>
+    </star-rating>
+    <image system="tvguide" type="backdrop">https://cdn.tvguide.co.uk/HighlightImages/Large/not_going_out.jpg</image>
+  </programme>
+  <programme channel="683.tvguide.co.uk" start="20230714213000 +0100" stop="20230714220000 +0100">
+    <title lang="en">Queen of Oz</title>
+    <sub-title lang="en">Emu Meat</sub-title>
+    <desc lang="en">At an official dinner, £ XGeorgie fails miserably in an attempt to drum up business for Australia, leading to scathing criticism from the media and the public. Stressed out, she has to get away and since she cannot drive, makes Marc drive her. Frustrated because there isn't any time to set up advanced security, he ends up taking her to the one place he knows she won't be spotted - his family's empty beach house. Back at Macquarie House, Georgie's staff take full advantage of her absence. Comedy, starring Catherine Tate and Rob Collins.</desc>
+    <credits>
+      <actor>Catherine Tate</actor>
+      <actor>Rob Collins</actor>
+    </credits>
+    <category lang="en">Comedy</category>
+    <url>https://www.tvguide.co.uk/detail/5161173/83998067/queen-of-oz</url>
+    <episode-num system="xmltv_ns">0 . 4/6 . </episode-num>
+    <subtitles type="teletext"/>
+    <star-rating>
+      <value>8.3/10</value>
+    </star-rating>
+    <image system="tvguide" type="backdrop">https://cdn.tvguide.co.uk/HighlightImages/Large/queen-of-oz.jpg</image>
+  </programme>
+
+</tv>


### PR DESCRIPTION
Appears that utf-8 chars are read from the xmltv OK but needed to be written with UTF8 explicitly specified.